### PR TITLE
Initial structural pass: Next.js App Router portfolio skeleton

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals", "next/typescript"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+# dependencies
+/node_modules
+
+# next.js
+/.next
+/out
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# local env files
+.env*.local
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/README.md
+++ b/README.md
@@ -1,0 +1,50 @@
+# JekkiJaneArt
+
+Многостраничный сайт-портфолио/коммерции художницы на Next.js (App Router) с подготовленной архитектурой для дальнейшего расширения.
+
+## Требования
+
+- Node.js 20
+- npm 10+ (или совместимый)
+
+## Установка
+
+```bash
+npm install
+```
+
+## Локальная разработка
+
+```bash
+npm run dev
+```
+
+Откройте `http://localhost:3000`.
+
+## Сборка
+
+```bash
+npm run build
+npm run start
+```
+
+## Деплой на Netlify
+
+- Проект совместим с стандартным деплоем Next.js App Router на Netlify.
+- Выберите репозиторий в Netlify, команда сборки: `npm run build`.
+- Версия Node: 20 (указать в настройках Netlify Environment / Build).
+
+## Структура папок
+
+```text
+src/
+  app/                 # маршруты и общий layout
+  components/
+    layout/
+    modals/
+    nav/
+    sections/
+  data/                # manifests и seed-данные
+  lib/                 # утилиты
+  styles/              # дополнительные стили (резерв)
+```

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,0 +1,5 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "jekki-jane-art",
+  "version": "0.1.0",
+  "private": true,
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.2.32",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "^20",
+    "@types/react": "^18",
+    "@types/react-dom": "^18",
+    "autoprefixer": "^10.4.20",
+    "eslint": "^8.57.1",
+    "eslint-config-next": "14.2.32",
+    "postcss": "^8.4.49",
+    "tailwindcss": "^3.4.17",
+    "typescript": "^5"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,0 +1,8 @@
+// About the artist page
+export default function AboutPage() {
+  return (
+    <section>
+      <h1>О художнице</h1>
+    </section>
+  );
+}

--- a/src/app/amulets/page.tsx
+++ b/src/app/amulets/page.tsx
@@ -1,0 +1,8 @@
+// Amulets page
+export default function AmuletsPage() {
+  return (
+    <section>
+      <h1>Картины-талисманы</h1>
+    </section>
+  );
+}

--- a/src/app/available/page.tsx
+++ b/src/app/available/page.tsx
@@ -1,0 +1,8 @@
+// Available works page
+export default function AvailablePage() {
+  return (
+    <section>
+      <h1>Готовые работы</h1>
+    </section>
+  );
+}

--- a/src/app/custom-paintings/page.tsx
+++ b/src/app/custom-paintings/page.tsx
@@ -1,0 +1,8 @@
+// Custom paintings page
+export default function CustomPaintingsPage() {
+  return (
+    <section>
+      <h1>Картины на заказ</h1>
+    </section>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,23 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  --accent: #7a4cff;
+  --accent-strong: #5f35d5;
+  --surface: #ffffff;
+  --radius: 0.75rem;
+  --nav-height-desktop: 7vh;
+  --nav-height-mobile: 17vh;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  min-height: 100%;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,26 @@
+import type { Metadata } from "next";
+import "./globals.css";
+import { BottomNavigation } from "@/components/nav/BottomNavigation";
+import { ModalProvider } from "@/components/modals/ModalProvider";
+
+export const metadata: Metadata = {
+  title: "Портфолио художницы",
+  description: "Описание сайта будет добавлено позже"
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="ru">
+      <body>
+        <ModalProvider>
+          <div className="min-h-screen">
+            <main className="pb-[calc(var(--nav-height-mobile)+env(safe-area-inset-bottom))] lg:pb-[var(--nav-height-desktop)]">
+              {children}
+            </main>
+            <BottomNavigation />
+          </div>
+        </ModalProvider>
+      </body>
+    </html>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,8 @@
+// Home page
+export default function HomePage() {
+  return (
+    <section>
+      <h1>Главная</h1>
+    </section>
+  );
+}

--- a/src/app/reviews/page.tsx
+++ b/src/app/reviews/page.tsx
@@ -1,0 +1,8 @@
+// Reviews page
+export default function ReviewsPage() {
+  return (
+    <section>
+      <h1>Отзывы</h1>
+    </section>
+  );
+}

--- a/src/app/tattoo/page.tsx
+++ b/src/app/tattoo/page.tsx
@@ -1,0 +1,8 @@
+// Tattoo sketches page
+export default function TattooPage() {
+  return (
+    <section>
+      <h1>Тату эскизы</h1>
+    </section>
+  );
+}

--- a/src/app/walls/page.tsx
+++ b/src/app/walls/page.tsx
@@ -1,0 +1,8 @@
+// Walls and furniture painting page
+export default function WallsPage() {
+  return (
+    <section>
+      <h1>Роспись стен и мебели</h1>
+    </section>
+  );
+}

--- a/src/app/wear-and-shoes/page.tsx
+++ b/src/app/wear-and-shoes/page.tsx
@@ -1,0 +1,8 @@
+// Wear and shoes painting page
+export default function WearAndShoesPage() {
+  return (
+    <section>
+      <h1>Роспись одежды и обуви</h1>
+    </section>
+  );
+}

--- a/src/components/modals/BaseModal.tsx
+++ b/src/components/modals/BaseModal.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { createPortal } from "react-dom";
+
+type BaseModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  children: React.ReactNode;
+};
+
+export function BaseModal({ isOpen, onClose, children }: BaseModalProps) {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    };
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [isOpen, onClose]);
+
+  const portalTarget = useMemo(() => (mounted ? document.body : null), [mounted]);
+
+  if (!isOpen || !portalTarget) {
+    return null;
+  }
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[1000] flex items-center justify-center bg-black/40 p-4"
+      onClick={onClose}
+      role="presentation"
+    >
+      <div
+        className="w-full max-w-lg rounded-md bg-white p-6"
+        role="dialog"
+        aria-modal="true"
+        onClick={(event) => event.stopPropagation()}
+      >
+        {children}
+      </div>
+    </div>,
+    portalTarget
+  );
+}

--- a/src/components/modals/ModalProvider.tsx
+++ b/src/components/modals/ModalProvider.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { createContext, useContext, useMemo, useState } from "react";
+import { BaseModal } from "@/components/modals/BaseModal";
+
+type ModalType = "order" | "certificates" | "siteCreator";
+
+type ModalContextValue = {
+  activeModal: ModalType | null;
+  openModal: (modal: ModalType) => void;
+  closeModal: () => void;
+};
+
+const ModalContext = createContext<ModalContextValue | undefined>(undefined);
+
+const modalPlaceholders: Record<ModalType, string> = {
+  order: "ORDER MODAL",
+  certificates: "CERTIFICATES MODAL",
+  siteCreator: "SITE CREATOR MODAL"
+};
+
+export function ModalProvider({ children }: { children: React.ReactNode }) {
+  const [activeModal, setActiveModal] = useState<ModalType | null>(null);
+
+  const value = useMemo(
+    () => ({
+      activeModal,
+      openModal: (modal: ModalType) => setActiveModal(modal),
+      closeModal: () => setActiveModal(null)
+    }),
+    [activeModal]
+  );
+
+  return (
+    <ModalContext.Provider value={value}>
+      {children}
+      <BaseModal isOpen={Boolean(activeModal)} onClose={value.closeModal}>
+        {activeModal ? modalPlaceholders[activeModal] : null}
+      </BaseModal>
+    </ModalContext.Provider>
+  );
+}
+
+export function useModal() {
+  const context = useContext(ModalContext);
+
+  if (!context) {
+    throw new Error("useModal must be used within a ModalProvider");
+  }
+
+  return context;
+}

--- a/src/components/nav/BottomNavigation.tsx
+++ b/src/components/nav/BottomNavigation.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useRouter, usePathname } from "next/navigation";
+import { orderedRoutes } from "@/data/routes";
+import { useModal } from "@/components/modals/ModalProvider";
+
+function navButtonClass(isActive: boolean) {
+  return `rounded border px-3 py-2 text-sm ${isActive ? "font-bold" : "font-normal"}`;
+}
+
+export function BottomNavigation() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const { openModal } = useModal();
+
+  const currentIndex = orderedRoutes.findIndex((route) => route.path === pathname);
+
+  const handlePrev = () => {
+    const safeIndex = currentIndex >= 0 ? currentIndex : 0;
+    const prevIndex = (safeIndex - 1 + orderedRoutes.length) % orderedRoutes.length;
+    router.push(orderedRoutes[prevIndex].path);
+  };
+
+  const handleNext = () => {
+    const safeIndex = currentIndex >= 0 ? currentIndex : 0;
+    const nextIndex = (safeIndex + 1) % orderedRoutes.length;
+    router.push(orderedRoutes[nextIndex].path);
+  };
+
+  return (
+    <nav className="fixed bottom-0 left-0 z-[100] w-full border-t bg-white" aria-label="Bottom navigation">
+      <div className="hidden min-h-[var(--nav-height-desktop)] items-center justify-center gap-2 px-4 lg:flex">
+        <button type="button" className={navButtonClass(false)} onClick={handlePrev} aria-label="Предыдущая страница">
+          ArrowPrev
+        </button>
+        <button type="button" className={navButtonClass(pathname === "/")} onClick={() => router.push("/")}>
+          На главную
+        </button>
+        <button type="button" className={navButtonClass(false)} onClick={() => openModal("siteCreator")}>
+          Создатель сайта
+        </button>
+        <button type="button" className={navButtonClass(false)} onClick={() => openModal("order")}>
+          Заказать
+        </button>
+        <button type="button" className={navButtonClass(pathname === "/reviews")} onClick={() => router.push("/reviews")}>
+          Отзывы
+        </button>
+        <button type="button" className={navButtonClass(false)} onClick={() => openModal("certificates")}>
+          Сертификаты
+        </button>
+        <button type="button" className={navButtonClass(false)} onClick={handleNext} aria-label="Следующая страница">
+          ArrowNext
+        </button>
+      </div>
+
+      <div
+        className="flex min-h-[var(--nav-height-mobile)] flex-col justify-center gap-2 px-4 py-2 lg:hidden"
+        style={{ paddingBottom: "env(safe-area-inset-bottom)" }}
+      >
+        <div className="grid grid-cols-2 gap-2">
+          <button type="button" className={navButtonClass(false)} onClick={() => openModal("order")}>
+            Заказать
+          </button>
+          <button type="button" className={navButtonClass(pathname === "/")} onClick={() => router.push("/")}>
+            НА ГЛАВНУЮ
+          </button>
+        </div>
+        <div className="grid grid-cols-3 gap-2">
+          <button type="button" className={navButtonClass(false)} onClick={() => openModal("certificates")}>
+            Сертификаты
+          </button>
+          <button type="button" className={navButtonClass(pathname === "/reviews")} onClick={() => router.push("/reviews")}>
+            Отзывы
+          </button>
+          <button type="button" className={navButtonClass(false)} onClick={() => openModal("siteCreator")}>
+            Создатель сайта
+          </button>
+        </div>
+      </div>
+    </nav>
+  );
+}

--- a/src/data/amuletsPics.ts
+++ b/src/data/amuletsPics.ts
@@ -1,0 +1,1 @@
+export const amuletsPics: Array<{ id: string; src: string; alt: string }> = [];

--- a/src/data/availablePics.ts
+++ b/src/data/availablePics.ts
@@ -1,0 +1,1 @@
+export const availablePics: Array<{ id: string; src: string; alt: string }> = [];

--- a/src/data/picToOrderPics.ts
+++ b/src/data/picToOrderPics.ts
@@ -1,0 +1,1 @@
+export const picToOrderPics: Array<{ id: string; src: string; alt: string }> = [];

--- a/src/data/reviewsSeed.ts
+++ b/src/data/reviewsSeed.ts
@@ -1,0 +1,7 @@
+export const reviewsSeed: Array<{ id: string; author: string; text: string }> = [
+  {
+    id: "placeholder-1",
+    author: "Гость",
+    text: "Черновик отзыва"
+  }
+];

--- a/src/data/routes.ts
+++ b/src/data/routes.ts
@@ -1,0 +1,11 @@
+export const orderedRoutes = [
+  { path: "/", label: "Главная" },
+  { path: "/available", label: "Готовые работы" },
+  { path: "/custom-paintings", label: "Картины на заказ" },
+  { path: "/amulets", label: "Картины-талисманы" },
+  { path: "/walls", label: "Роспись стен и мебели" },
+  { path: "/wear-and-shoes", label: "Роспись одежды и обуви" },
+  { path: "/tattoo", label: "Тату эскизы" },
+  { path: "/about", label: "О художнице" },
+  { path: "/reviews", label: "Отзывы" }
+] as const;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,15 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: [
+    "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/app/**/*.{js,ts,jsx,tsx,mdx}"
+  ],
+  theme: {
+    extend: {}
+  },
+  plugins: []
+};
+
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
### Motivation
- Scaffold a strict-TypeScript Next.js (App Router) portfolio/commerce site with Tailwind, basic tooling and a clear expandable architecture targeted for Netlify and Node 20. 
- Provide a structural, accessible navigation and modal framework plus data-manifest placeholders so UI/animation work can be added later without breaking routing or project layout.

### Description
- Added project configuration and tooling files including `package.json`, `tsconfig.json`, `next.config.ts`, `tailwind.config.ts`, `postcss.config.js`, and `.eslintrc.json` to enforce strict TypeScript and Node 20 compatibility. 
- Created `src/` skeleton and the requested routes with placeholder pages (each file exports a default component and contains a Russian `<h1>`): `/`, `/available`, `/custom-paintings`, `/amulets`, `/walls`, `/wear-and-shoes`, `/tattoo`, `/about`, `/reviews`.
- Implemented global layout in `src/app/layout.tsx` that imports `globals.css`, wraps children with `ModalProvider`, always renders `BottomNavigation`, and applies bottom padding to avoid nav overlap for desktop (`--nav-height-desktop`) and mobile (`--nav-height-mobile` + safe-area).
- Implemented `BottomNavigation` client component (`src/components/nav/BottomNavigation.tsx`) with desktop and mobile responsive variants, cyclic previous/next navigation using `orderedRoutes`, active-route highlight, and modal triggers; implemented modal framework with `ModalProvider` and `BaseModal` (`src/components/modals/*`) using context and portal rendering, backdrop and `Escape` close behavior; added data manifests (`src/data/*`) and CSS theme tokens in `src/app/globals.css`; added `README.md` with local and Netlify notes.

### Testing
- Attempted to install dependencies with `npm install`, but the run failed with a `403 Forbidden` from the npm registry, so install/build/lint steps could not be executed in this environment. 
- Attempted an automated browser check (Playwright) to hit `http://127.0.0.1:3000` and capture a screenshot, but the request returned `ERR_EMPTY_RESPONSE` because the dev server was not started (build/install not run). 
- No further automated `build`/`lint` or runtime tests were executed due to the dependency install failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bfd8bd008832e8f4a098b1cc29641)