### PR TITLE
Pass 2A (redo): widgets + backgrounds + base layouts

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals", "next/typescript"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+# dependencies
+/node_modules
+
+# next.js
+/.next
+/out
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# local env files
+.env*.local
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/README.md
+++ b/README.md
@@ -1,0 +1,50 @@
+# JekkiJaneArt
+
+Многостраничный сайт-портфолио/коммерции художницы на Next.js (App Router) с подготовленной архитектурой для дальнейшего расширения.
+
+## Требования
+
+- Node.js 20
+- npm 10+ (или совместимый)
+
+## Установка
+
+```bash
+npm install
+```
+
+## Локальная разработка
+
+```bash
+npm run dev
+```
+
+Откройте `http://localhost:3000`.
+
+## Сборка
+
+```bash
+npm run build
+npm run start
+```
+
+## Деплой на Netlify
+
+- Проект совместим с стандартным деплоем Next.js App Router на Netlify.
+- Выберите репозиторий в Netlify, команда сборки: `npm run build`.
+- Версия Node: 20 (указать в настройках Netlify Environment / Build).
+
+## Структура папок
+
+```text
+src/
+  app/                 # маршруты и общий layout
+  components/
+    layout/
+    modals/
+    nav/
+    sections/
+  data/                # manifests и seed-данные
+  lib/                 # утилиты
+  styles/              # дополнительные стили (резерв)
+```

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "jekki-jane-art",
+  "version": "0.1.0",
+  "private": true,
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.2.32",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "^20",
+    "@types/react": "^18",
+    "@types/react-dom": "^18",
+    "autoprefixer": "^10.4.20",
+    "eslint": "^8.57.1",
+    "eslint-config-next": "14.2.32",
+    "postcss": "^8.4.49",
+    "tailwindcss": "^3.4.17",
+    "typescript": "^5"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,0 +1,27 @@
+// About the artist page
+import Image from "next/image";
+import { PageBackground } from "@/components/layout/PageBackground";
+
+export default function AboutPage() {
+  return (
+    <PageBackground backgroundSrc="/mainpage/mainpage-back.png">
+      <section className="space-y-6">
+        <h1 className="text-center text-3xl font-semibold tracking-wide">JEKKI JANE</h1>
+        <div className="grid gap-4 lg:grid-cols-3 lg:items-center">
+          <div className="overflow-hidden rounded-xl border border-[var(--border)]">
+            <Image src="/about/person2.png" alt="Художница Jekki Jane, портрет слева" width={900} height={1200} className="h-full w-full object-cover" />
+          </div>
+          <div className="rounded-xl border border-[var(--border)] bg-[var(--card-bg)] p-5 text-sm leading-6 lg:text-base">
+            Привет! Я Jekki Jane — художница, которая работает на стыке живописи, росписи и авторских эскизов. Для
+            меня важно, чтобы каждая работа отражала характер человека и пространства, для которого она создаётся.
+            Люблю детали, чистую композицию и живой цвет. В проектах ценю открытый диалог, точность и бережное
+            отношение к каждой идее.
+          </div>
+          <div className="overflow-hidden rounded-xl border border-[var(--border)]">
+            <Image src="/about/person1.png" alt="Художница Jekki Jane, портрет справа" width={900} height={1200} className="h-full w-full object-cover" />
+          </div>
+        </div>
+      </section>
+    </PageBackground>
+  );
+}

--- a/src/app/amulets/page.tsx
+++ b/src/app/amulets/page.tsx
@@ -1,0 +1,14 @@
+// Amulets page
+import { PageBackground } from "@/components/layout/PageBackground";
+
+export default function AmuletsPage() {
+  return (
+    <PageBackground>
+      <section className="space-y-6">
+        <div className="rounded-xl border border-[var(--border)] bg-[var(--card-bg)] p-5">
+          Лента амулетов и drawer будут добавлены на следующем шаге.
+        </div>
+      </section>
+    </PageBackground>
+  );
+}

--- a/src/app/available/page.tsx
+++ b/src/app/available/page.tsx
@@ -1,0 +1,13 @@
+// Available works page
+import { PageBackground } from "@/components/layout/PageBackground";
+
+export default function AvailablePage() {
+  return (
+    <PageBackground backgroundSrc="/availablepics/back-full.png">
+      <section className="space-y-6">
+        <h1 className="text-2xl font-semibold">Готовые работы</h1>
+        <div className="rounded-xl border border-[var(--border)] bg-[var(--card-bg)] p-5">Карусель будет добавлена на следующем шаге.</div>
+      </section>
+    </PageBackground>
+  );
+}

--- a/src/app/custom-paintings/page.tsx
+++ b/src/app/custom-paintings/page.tsx
@@ -1,0 +1,20 @@
+// Custom paintings page
+import { PageBackground } from "@/components/layout/PageBackground";
+
+export default function CustomPaintingsPage() {
+  return (
+    <PageBackground backgroundSrc="/mainpage/mainpage-back.png">
+      <section className="space-y-6">
+        <h1 className="text-2xl font-semibold">Картина, созданная специально для вас</h1>
+        <div className="grid gap-4 lg:grid-cols-2">
+          <div className="rounded-xl border border-[var(--border)] bg-[var(--card-bg)] p-5">
+            Окна-аккордеон будут добавлены на следующем шаге.
+          </div>
+          <div className="rounded-xl border border-[var(--border)] bg-[var(--card-bg)] p-5">
+            Карусель будет добавлена на следующем шаге.
+          </div>
+        </div>
+      </section>
+    </PageBackground>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,34 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  --accent: #8f6a4f;
+  --accent-strong: #6f4e37;
+  --surface: #ffffff;
+  --radius: 0.75rem;
+  --nav-height-desktop: 7vh;
+  --nav-height-mobile: 17vh;
+  --text: #111111;
+  --muted: #6b7280;
+  --border: rgba(0, 0, 0, 0.12);
+  --modal-bg: rgba(0, 0, 0, 0.45);
+  --card-bg: rgba(255, 255, 255, 0.78);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  min-height: 100%;
+}
+
+body {
+  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: #fff;
+  color: var(--text);
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,26 @@
+import type { Metadata } from "next";
+import "./globals.css";
+import { BottomNavigation } from "@/components/nav/BottomNavigation";
+import { ModalProvider } from "@/components/modals/ModalProvider";
+
+export const metadata: Metadata = {
+  title: "Портфолио художницы",
+  description: "Описание сайта будет добавлено позже"
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="ru">
+      <body>
+        <ModalProvider>
+          <div className="min-h-screen">
+            <main className="pb-[calc(var(--nav-height-mobile)+env(safe-area-inset-bottom))] lg:pb-[var(--nav-height-desktop)]">
+              {children}
+            </main>
+            <BottomNavigation />
+          </div>
+        </ModalProvider>
+      </body>
+    </html>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,31 @@
+// Home page
+import Image from "next/image";
+import { PageBackground } from "@/components/layout/PageBackground";
+
+export default function HomePage() {
+  return (
+    <PageBackground backgroundSrc="/mainpage/mainpage-back.png">
+      <section className="flex min-h-[70vh] flex-col items-center justify-center gap-6 text-center">
+        <Image
+          src="/mainpage/mainpage-icon-mobile.png"
+          alt="JEKKI JANE ART"
+          width={220}
+          height={220}
+          priority
+          className="h-auto w-[220px] lg:hidden"
+        />
+        <Image
+          src="/mainpage/mainpage-icon.png"
+          alt="JEKKI JANE ART"
+          width={300}
+          height={300}
+          priority
+          className="hidden h-auto w-[300px] lg:block"
+        />
+        <div className="max-w-xl rounded-xl border border-[var(--border)] bg-[var(--card-bg)] p-4 text-sm lg:text-base">
+          Главная: SVG-сектора будут добавлены на следующем шаге.
+        </div>
+      </section>
+    </PageBackground>
+  );
+}

--- a/src/app/reviews/page.tsx
+++ b/src/app/reviews/page.tsx
@@ -1,0 +1,48 @@
+// Reviews page
+import Image from "next/image";
+import { PageBackground } from "@/components/layout/PageBackground";
+
+export default function ReviewsPage() {
+  return (
+    <PageBackground backgroundSrc="/mainpage/mainpage-back.png">
+      <section className="space-y-6">
+        <h1 className="text-2xl font-semibold">Отзывы</h1>
+        <div className="flex flex-col gap-4 lg:flex-row">
+          <article className="mx-auto flex w-[90vw] max-w-[340px] flex-col overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--card-bg)] lg:mx-0 lg:h-[340px] lg:w-[340px]">
+            <div className="flex-1 p-4 text-sm leading-6">
+              Здесь размещаются:
+              <br />
+              <br />
+              текстовые отзывы
+              <br />
+              <br />
+              фото клиентов с работами
+              <br />
+              <br />
+              отзывы о росписи
+              <br />
+              <br />
+              отзывы о портретах
+            </div>
+            <div className="relative flex-1">
+              <Image
+                src="/reweivs/b8f48cb5-13c0-4ae2-a08a-30801e5e5c88.png"
+                alt="Пример клиентского отзыва"
+                fill
+                className="object-cover"
+                sizes="(max-width: 1024px) 90vw, 340px"
+              />
+            </div>
+          </article>
+
+          <article className="mx-auto flex aspect-square w-[90vw] max-w-[340px] items-center justify-center rounded-xl border border-[var(--border)] bg-[var(--card-bg)] lg:mx-0 lg:h-[340px] lg:w-[340px]">
+            <div className="flex flex-col items-center gap-3 text-center text-sm">
+              <span className="flex h-12 w-12 items-center justify-center rounded-full border border-[var(--border)] text-2xl">+</span>
+              <span>добавить отзыв</span>
+            </div>
+          </article>
+        </div>
+      </section>
+    </PageBackground>
+  );
+}

--- a/src/app/tattoo/page.tsx
+++ b/src/app/tattoo/page.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+// Tattoo sketches page
+import Image from "next/image";
+import { PageBackground } from "@/components/layout/PageBackground";
+import { useModal } from "@/components/modals/ModalProvider";
+
+export default function TattooPage() {
+  const { openModal } = useModal();
+
+  return (
+    <PageBackground backgroundSrc="/mainpage/mainpage-back.png">
+      <section className="grid gap-5 lg:grid-cols-2 lg:items-center">
+        <div className="order-1 space-y-4 rounded-xl border border-[var(--border)] bg-[var(--card-bg)] p-5">
+          <h1 className="text-2xl font-semibold lg:text-3xl">Тату эскизы</h1>
+          <p className="text-sm leading-6 lg:text-base">
+            Разрабатываю авторские тату-эскизы под вашу идею и анатомию. Учитываю стиль, размер, место нанесения и
+            индивидуальные предпочтения, чтобы эскиз был выразительным и удобным для дальнейшей работы мастера.
+          </p>
+          <button
+            type="button"
+            onClick={() => openModal("order")}
+            className="rounded-lg border border-[var(--border)] bg-[var(--surface)] px-4 py-2 text-sm font-medium transition hover:bg-gray-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--accent)]"
+          >
+            начать работу над эскизом
+          </button>
+        </div>
+        <div className="order-2 overflow-hidden rounded-xl border border-[var(--border)]">
+          <Image src="/tattoo/1.png" alt="Пример тату-эскиза" width={1000} height={1300} className="h-full w-full object-cover" />
+        </div>
+      </section>
+    </PageBackground>
+  );
+}

--- a/src/app/walls/page.tsx
+++ b/src/app/walls/page.tsx
@@ -1,0 +1,46 @@
+// Walls and furniture painting page
+import Image from "next/image";
+import { PageBackground } from "@/components/layout/PageBackground";
+
+const wallSections = [
+  {
+    image: "/walls/1.png",
+    text: "Роспись стен и мебели превращает пространство в личную историю и задаёт характер интерьеру."
+  },
+  {
+    image: "/walls/2.png",
+    text: "Подбираю стиль и цветовую палитру под ваш интерьер, чтобы роспись выглядела цельно и современно."
+  },
+  {
+    image: "/walls/3.png",
+    text: "Работаю с квартирами, студиями, детскими комнатами, коммерческими и общественными пространствами."
+  },
+  {
+    image: "/walls/4.png",
+    text: "Использую материалы, рассчитанные на долговечность, с аккуратной проработкой деталей и линий."
+  },
+  {
+    image: "/walls/5.jpg",
+    text: "Перед стартом согласуем эскиз, размеры, сроки и бюджет, чтобы итог полностью соответствовал ожиданиям."
+  }
+];
+
+export default function WallsPage() {
+  return (
+    <PageBackground backgroundSrc="/mainpage/mainpage-back.png">
+      <section className="space-y-6">
+        <h1 className="text-2xl font-semibold lg:text-3xl">Создание уникального дизайна для вашего пространства</h1>
+        <div className="space-y-4">
+          {wallSections.map((item) => (
+            <article key={item.image} className="grid gap-3 rounded-xl border border-[var(--border)] bg-[var(--card-bg)] p-4 lg:grid-cols-2 lg:items-center">
+              <div className="order-2 lg:order-1">
+                <Image src={item.image} alt="Пример росписи стен и мебели" width={1200} height={800} className="h-auto w-full rounded-lg object-cover" />
+              </div>
+              <p className="order-1 text-sm leading-6 lg:order-2 lg:text-base">{item.text}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+    </PageBackground>
+  );
+}

--- a/src/app/wear-and-shoes/page.tsx
+++ b/src/app/wear-and-shoes/page.tsx
@@ -1,0 +1,26 @@
+// Wear and shoes painting page
+import Image from "next/image";
+import { PageBackground } from "@/components/layout/PageBackground";
+
+export default function WearAndShoesPage() {
+  return (
+    <PageBackground backgroundSrc="/mainpage/mainpage-back.png">
+      <section className="space-y-6">
+        <h1 className="text-2xl font-semibold lg:text-3xl">Создание дизайнерского облика для вашей одежды и обуви</h1>
+        <div className="grid gap-4 lg:grid-cols-3 lg:items-stretch">
+          <div className="order-2 overflow-hidden rounded-xl border border-[var(--border)] lg:order-1">
+            <Image src="/wear-and-shoes/1.png" alt="Роспись одежды и обуви, пример 1" width={900} height={1200} className="h-full w-full object-cover" />
+          </div>
+          <div className="order-1 rounded-xl border border-[var(--border)] bg-[var(--card-bg)] p-5 text-sm leading-6 lg:order-2 lg:text-base">
+            Я создаю индивидуальную роспись на одежде и обуви: от аккуратных акцентов до ярких авторских композиций.
+            Работа начинается с вашей идеи, после чего мы согласуем эскиз, палитру и детали. В результате вы получаете
+            уникальную вещь, которая подчёркивает ваш стиль и сохраняет свою выразительность в повседневной носке.
+          </div>
+          <div className="order-3 overflow-hidden rounded-xl border border-[var(--border)]">
+            <Image src="/wear-and-shoes/2.JPEG" alt="Роспись одежды и обуви, пример 2" width={900} height={1200} className="h-full w-full object-cover" />
+          </div>
+        </div>
+      </section>
+    </PageBackground>
+  );
+}

--- a/src/components/layout/PageBackground.tsx
+++ b/src/components/layout/PageBackground.tsx
@@ -1,0 +1,25 @@
+import Image from "next/image";
+
+type PageBackgroundProps = {
+  backgroundSrc?: string;
+  children: React.ReactNode;
+};
+
+export function PageBackground({ backgroundSrc, children }: PageBackgroundProps) {
+  return (
+    <div className="relative min-h-screen">
+      {backgroundSrc ? (
+        <Image
+          src={backgroundSrc}
+          alt="Фоновое изображение"
+          fill
+          priority
+          className="object-cover"
+          sizes="100vw"
+        />
+      ) : null}
+      {backgroundSrc ? <div className="absolute inset-0 bg-white/45" aria-hidden="true" /> : null}
+      <div className="relative z-10 mx-auto w-full max-w-6xl px-4 py-8 lg:px-8 lg:py-12">{children}</div>
+    </div>
+  );
+}

--- a/src/components/modals/BaseModal.tsx
+++ b/src/components/modals/BaseModal.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { createPortal } from "react-dom";
+
+type BaseModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  children: React.ReactNode;
+};
+
+export function BaseModal({ isOpen, onClose, children }: BaseModalProps) {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    };
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [isOpen, onClose]);
+
+  const portalTarget = useMemo(() => (mounted ? document.body : null), [mounted]);
+
+  if (!isOpen || !portalTarget) {
+    return null;
+  }
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[1000] flex items-end justify-center bg-[var(--modal-bg)] p-0 lg:items-center lg:p-4"
+      onClick={onClose}
+      role="presentation"
+    >
+      <div
+        className="max-h-[80vh] w-full overflow-y-auto rounded-t-2xl bg-[var(--surface)] p-5 pb-[calc(1.25rem+env(safe-area-inset-bottom))] lg:max-h-[90vh] lg:max-w-lg lg:rounded-md lg:p-6"
+        role="dialog"
+        aria-modal="true"
+        onClick={(event) => event.stopPropagation()}
+      >
+        {children}
+      </div>
+    </div>,
+    portalTarget
+  );
+}

--- a/src/components/modals/CertificatesModalContent.tsx
+++ b/src/components/modals/CertificatesModalContent.tsx
@@ -1,0 +1,24 @@
+import Image from "next/image";
+
+export function CertificatesModalContent() {
+  return (
+    <div className="flex h-full min-h-[420px] flex-col gap-4">
+      <div className="rounded-xl border border-[var(--border)] bg-[var(--card-bg)] p-4 text-sm leading-6 lg:basis-1/3">
+        <p>
+          Подарочный сертификат на:
+          <br />
+          любую услугу
+          <br />
+          любую сумму
+          <br />
+          Возможен электронный и печатный формат.
+          <br />
+          Срок действия: 1 год
+        </p>
+      </div>
+      <div className="relative min-h-[220px] flex-1 overflow-hidden rounded-xl border border-[var(--border)] lg:basis-2/3">
+        <Image src="/sertificates/1.png" alt="Подарочный сертификат" fill className="object-contain bg-white" sizes="(max-width: 1024px) 100vw, 50vw" />
+      </div>
+    </div>
+  );
+}

--- a/src/components/modals/ModalProvider.tsx
+++ b/src/components/modals/ModalProvider.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { createContext, useContext, useMemo, useState } from "react";
+import { BaseModal } from "@/components/modals/BaseModal";
+import { OrderModalContent } from "@/components/modals/OrderModalContent";
+import { CertificatesModalContent } from "@/components/modals/CertificatesModalContent";
+import { SiteCreatorModalContent } from "@/components/modals/SiteCreatorModalContent";
+
+type ModalType = "order" | "certificates" | "siteCreator";
+
+type ModalContextValue = {
+  activeModal: ModalType | null;
+  openModal: (modal: ModalType) => void;
+  closeModal: () => void;
+};
+
+const ModalContext = createContext<ModalContextValue | undefined>(undefined);
+
+function renderModalContent(modal: ModalType | null) {
+  switch (modal) {
+    case "order":
+      return <OrderModalContent />;
+    case "certificates":
+      return <CertificatesModalContent />;
+    case "siteCreator":
+      return <SiteCreatorModalContent />;
+    default:
+      return null;
+  }
+}
+
+export function ModalProvider({ children }: { children: React.ReactNode }) {
+  const [activeModal, setActiveModal] = useState<ModalType | null>(null);
+
+  const value = useMemo(
+    () => ({
+      activeModal,
+      openModal: (modal: ModalType) => setActiveModal(modal),
+      closeModal: () => setActiveModal(null)
+    }),
+    [activeModal]
+  );
+
+  return (
+    <ModalContext.Provider value={value}>
+      {children}
+      <BaseModal isOpen={Boolean(activeModal)} onClose={value.closeModal}>
+        {renderModalContent(activeModal)}
+      </BaseModal>
+    </ModalContext.Provider>
+  );
+}
+
+export function useModal() {
+  const context = useContext(ModalContext);
+
+  if (!context) {
+    throw new Error("useModal must be used within a ModalProvider");
+  }
+
+  return context;
+}

--- a/src/components/modals/OrderModalContent.tsx
+++ b/src/components/modals/OrderModalContent.tsx
@@ -1,0 +1,69 @@
+import Image from "next/image";
+
+const linkClass =
+  "flex h-12 w-12 items-center justify-center rounded-full border border-[var(--border)] bg-white transition hover:bg-gray-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--accent)]";
+
+export function OrderModalContent() {
+  return (
+    <div className="space-y-5 text-sm leading-6 text-[var(--text)]">
+      <p>
+        Чтобы оформить заказ, просто свяжитесь со мной удобным способом:
+        <br />
+        Telegram: @zzzhekichannnn
+        <br />
+        Instagram: @JEKKI.JANE.ART
+        <br />
+        WhatsApp / Телефон: 8 925 919-88-46
+      </p>
+
+      <div className="flex items-center gap-3">
+        <a
+          href="https://t.me/zzzhekichannnn"
+          target="_blank"
+          rel="noreferrer"
+          className={linkClass}
+          aria-label="Написать в Telegram"
+        >
+          <Image src="/Telegram_logo.svg.png" alt="Telegram" width={28} height={28} />
+        </a>
+        <a
+          href="https://www.instagram.com/jekki.jane.art"
+          target="_blank"
+          rel="noreferrer"
+          className={linkClass}
+          aria-label="Открыть Instagram"
+        >
+          <Image src="/Instagram_icon.png" alt="Instagram" width={28} height={28} />
+        </a>
+        <a
+          href="https://vk.ru/id437361077"
+          target="_blank"
+          rel="noreferrer"
+          className={linkClass}
+          aria-label="Открыть VK"
+        >
+          <Image src="/vk-logo.png" alt="VK" width={28} height={28} />
+        </a>
+      </div>
+
+      <div className="space-y-2">
+        <p>Далее всё просто:</p>
+        <ul className="list-inside list-disc space-y-1 text-[var(--muted)]">
+          <li>Напишите мне в Direct / Telegram / WhatsApp</li>
+          <li>Опишите ваш запрос (идея, размер, формат, пожелания)</li>
+          <li>Мы согласуем детали и сроки</li>
+        </ul>
+      </div>
+
+      <div className="space-y-2">
+        <p>Доставка:</p>
+        <ul className="list-inside list-disc space-y-1 text-[var(--muted)]">
+          <li>По России — СДЭК / Почта</li>
+          <li>Международная доставка — по запросу</li>
+          <li>Самовывоз — по договоренности</li>
+        </ul>
+        <p>Картины упаковываются в защитную пленку и коробку.</p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/modals/SiteCreatorModalContent.tsx
+++ b/src/components/modals/SiteCreatorModalContent.tsx
@@ -1,0 +1,29 @@
+import Image from "next/image";
+
+const linkClass =
+  "flex h-12 w-12 items-center justify-center rounded-full border border-[var(--border)] bg-white transition hover:bg-gray-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--accent)]";
+
+export function SiteCreatorModalContent() {
+  return (
+    <div className="space-y-5 text-sm leading-6">
+      <p>
+        разработка дизайна и создание сайта под любые цели под индивидуальный запрос, адаптация под все устройства,
+        быстрое исполнение, демократичные цены, действуют скидки
+      </p>
+      <div className="flex items-center gap-3">
+        <a href="https://t.me/magimist" target="_blank" rel="noreferrer" className={linkClass} aria-label="Связаться с создателем сайта в Telegram">
+          <Image src="/Telegram_logo.svg.png" alt="Telegram" width={28} height={28} />
+        </a>
+        <a
+          href="https://www.instagram.com/magistr_iney"
+          target="_blank"
+          rel="noreferrer"
+          className={linkClass}
+          aria-label="Открыть Instagram создателя сайта"
+        >
+          <Image src="/Instagram_icon.png" alt="Instagram" width={28} height={28} />
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/src/components/nav/BottomNavigation.tsx
+++ b/src/components/nav/BottomNavigation.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useRouter, usePathname } from "next/navigation";
+import { orderedRoutes } from "@/data/routes";
+import { useModal } from "@/components/modals/ModalProvider";
+
+function navButtonClass(isActive: boolean) {
+  return `rounded border border-[var(--border)] bg-[var(--surface)] px-3 py-2 text-sm transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--accent)] ${
+    isActive ? "font-bold" : "font-normal"
+  }`;
+}
+
+export function BottomNavigation() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const { openModal } = useModal();
+
+  const currentIndex = orderedRoutes.findIndex((route) => route.path === pathname);
+
+  const handlePrev = () => {
+    const safeIndex = currentIndex >= 0 ? currentIndex : 0;
+    const prevIndex = (safeIndex - 1 + orderedRoutes.length) % orderedRoutes.length;
+    router.push(orderedRoutes[prevIndex].path);
+  };
+
+  const handleNext = () => {
+    const safeIndex = currentIndex >= 0 ? currentIndex : 0;
+    const nextIndex = (safeIndex + 1) % orderedRoutes.length;
+    router.push(orderedRoutes[nextIndex].path);
+  };
+
+  return (
+    <nav className="fixed bottom-0 left-0 z-[100] w-full border-t border-[var(--border)] bg-[var(--surface)]" aria-label="Bottom navigation">
+      <div className="hidden min-h-[var(--nav-height-desktop)] items-center justify-center gap-2 px-4 lg:flex">
+        <button type="button" className={navButtonClass(false)} onClick={handlePrev} aria-label="Предыдущая страница">
+          ArrowPrev
+        </button>
+        <button type="button" className={navButtonClass(pathname === "/")} onClick={() => router.push("/")}>
+          На главную
+        </button>
+        <button type="button" className={navButtonClass(false)} onClick={() => openModal("siteCreator")}>
+          Создатель сайта
+        </button>
+        <button type="button" className={navButtonClass(false)} onClick={() => openModal("order")}>
+          Заказать
+        </button>
+        <button type="button" className={navButtonClass(pathname === "/reviews")} onClick={() => router.push("/reviews")}>
+          Отзывы
+        </button>
+        <button type="button" className={navButtonClass(false)} onClick={() => openModal("certificates")}>
+          Сертификаты
+        </button>
+        <button type="button" className={navButtonClass(false)} onClick={handleNext} aria-label="Следующая страница">
+          ArrowNext
+        </button>
+      </div>
+
+      <div
+        className="flex min-h-[var(--nav-height-mobile)] flex-col justify-center gap-2 bg-[var(--surface)] px-4 py-2 lg:hidden"
+        style={{ paddingBottom: "env(safe-area-inset-bottom)" }}
+      >
+        <div className="grid grid-cols-2 gap-2">
+          <button type="button" className={navButtonClass(false)} onClick={() => openModal("order")}>
+            Заказать
+          </button>
+          <button type="button" className={navButtonClass(pathname === "/")} onClick={() => router.push("/")}>
+            НА ГЛАВНУЮ
+          </button>
+        </div>
+        <div className="grid grid-cols-3 gap-2">
+          <button type="button" className={navButtonClass(false)} onClick={() => openModal("certificates")}>
+            Сертификаты
+          </button>
+          <button type="button" className={navButtonClass(pathname === "/reviews")} onClick={() => router.push("/reviews")}>
+            Отзывы
+          </button>
+          <button type="button" className={navButtonClass(false)} onClick={() => openModal("siteCreator")}>
+            Создатель сайта
+          </button>
+        </div>
+      </div>
+    </nav>
+  );
+}

--- a/src/data/amuletsPics.ts
+++ b/src/data/amuletsPics.ts
@@ -1,0 +1,1 @@
+export const amuletsPics: Array<{ id: string; src: string; alt: string }> = [];

--- a/src/data/availablePics.ts
+++ b/src/data/availablePics.ts
@@ -1,0 +1,1 @@
+export const availablePics: Array<{ id: string; src: string; alt: string }> = [];

--- a/src/data/picToOrderPics.ts
+++ b/src/data/picToOrderPics.ts
@@ -1,0 +1,1 @@
+export const picToOrderPics: Array<{ id: string; src: string; alt: string }> = [];

--- a/src/data/reviewsSeed.ts
+++ b/src/data/reviewsSeed.ts
@@ -1,0 +1,7 @@
+export const reviewsSeed: Array<{ id: string; author: string; text: string }> = [
+  {
+    id: "placeholder-1",
+    author: "Гость",
+    text: "Черновик отзыва"
+  }
+];

--- a/src/data/routes.ts
+++ b/src/data/routes.ts
@@ -1,0 +1,11 @@
+export const orderedRoutes = [
+  { path: "/", label: "Главная" },
+  { path: "/available", label: "Готовые работы" },
+  { path: "/custom-paintings", label: "Картины на заказ" },
+  { path: "/amulets", label: "Картины-талисманы" },
+  { path: "/walls", label: "Роспись стен и мебели" },
+  { path: "/wear-and-shoes", label: "Роспись одежды и обуви" },
+  { path: "/tattoo", label: "Тату эскизы" },
+  { path: "/about", label: "О художнице" },
+  { path: "/reviews", label: "Отзывы" }
+] as const;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,15 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: [
+    "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/app/**/*.{js,ts,jsx,tsx,mdx}"
+  ],
+  theme: {
+    extend: {}
+  },
+  plugins: []
+};
+
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
### Motivation
- Redo the Pass 2A feature set cleanly on top of main to avoid merge conflicts and preserve the intended UI/layouts and widgets.
- Re-apply page backgrounds, baseline responsive layouts and modal/widget content while keeping the project on Next.js App Router with strict TypeScript and Tailwind.
- Ensure correct background asset usage and simple, robust navigation/modal behavior with accessible fallbacks and safe z-index ordering.

### Description
- Added a reusable `PageBackground` component and applied it across pages, using `/mainpage/mainpage-back.png` for all pages except `/available` (uses `/availablepics/back-full.png`) and `/amulets` (no global background). 
- Re-created page routes and baseline layouts: `src/app/page.tsx` (home with responsive logo swap), `about`, `amulets`, `available`, `custom-paintings`, `reviews`, `tattoo`, `walls`, and `wear-and-shoes` with placeholders and responsive structure. 
- Implemented modal system: `BaseModal` (fixed portal with `z-[1000]`), `ModalProvider`, and modal contents `OrderModalContent`, `CertificatesModalContent`, and `SiteCreatorModalContent` with real Russian text and the requested social buttons (3 in order modal, 2 in siteCreator). 
- Implemented `BottomNavigation` with navigation logic preserved and `z-[100]`, plus lightweight styling; added small data/seed placeholders (`src/data/*`) and project config/styling files (`next.config.mjs`, `tsconfig.json`, `tailwind.config.ts`, `postcss.config.js`, `package.json`, `src/app/globals.css`, `.eslintrc.json`, `.gitignore`, `README.md`).

### Testing
- Ran `npm run build` and the Next.js production build completed successfully with compilation, type checking, linting and static pages generation. (success)
- Ran `npm run dev` to verify local startup and page rendering (dev server started and pages compiled). (success)
- Captured a browser screenshot of the Home page via an automated Playwright run to verify the responsive logo and background rendering. (success)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bfd8bd008832e8f4a098b1cc29641)